### PR TITLE
Update webBackup.sh

### DIFF
--- a/webBackup.sh
+++ b/webBackup.sh
@@ -53,7 +53,7 @@ function backup_database {
     then
         # save database
         echo 'Save database...'
-        mysqldump --single-transaction --skip-lock-tables --net_buffer_length 16384 -u root $database_name > $backup_database_path/$datetime.sql
+        mysqldump --complete-insert --routines --triggers --single-transaction --skip-lock-tables --net_buffer_length 16384 -u root $database_name > $backup_database_path/$datetime.sql
 		cp $backup_database_path/$datetime.sql $backup_database_path/last.sql
         echo 'Success'
     fi


### PR DESCRIPTION
# Description
```
--complete-insert, -c
Use complete INSERT statements that include column names. 

--routines, -R
Include stored routines (procedures and functions) for the dumped databases in the output. This option requires the global SELECT privilege.
The output generated by using --routines contains CREATE PROCEDURE and CREATE FUNCTION statements to create the routines. 

--triggers
Include triggers for each dumped table in the output. This option is enabled by default; disable it with --skip-triggers.
To be able to dump a table's triggers, you must have the TRIGGER privilege for the table.
Multiple triggers are permitted. mysqldump dumps triggers in activation order so that when the dump file is reloaded, triggers are created in the same activation order. However, if a mysqldump dump file contains multiple triggers for a table that have the same trigger event and action time, an error occurs for attempts to load the dump file into an older server that does not support multiple triggers. (For a workaround, see Downgrade Notes; you can convert triggers to be compatible with older servers.) 
```

# How Has This Been Tested?
of course

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
